### PR TITLE
修复 bxi_example_hw 启动锁的跨用户权限问题

### DIFF
--- a/src/bxi_example_py_elf3/launch/example_demo_hw.launch.py
+++ b/src/bxi_example_py_elf3/launch/example_demo_hw.launch.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import fcntl
+import atexit
 from ament_index_python.packages import get_package_share_path
 from launch import LaunchDescription
 from launch_ros.actions import Node
@@ -8,20 +9,73 @@ from launch_ros.actions import Node
 LOCK_FILE = "/tmp/bxi_example_hw.lock"
 _lock_fd = None
 
+
+def _release_lock():
+    global _lock_fd
+    if _lock_fd is None:
+        return
+    fd = _lock_fd
+    _lock_fd = None
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    except OSError:
+        pass
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+
 def _acquire_lock():
     global _lock_fd
-    _lock_fd = open(LOCK_FILE, "w")
+    if _lock_fd is not None:
+        return
+
+    # Create the lock file world-writable so a different user (or root)
+    # can reuse the same system-wide lock. Force umask to 0 so the 0o666
+    # mode is honored on creation regardless of the caller's umask.
+    old_umask = os.umask(0)
     try:
-        fcntl.flock(_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            fd = os.open(LOCK_FILE, os.O_RDWR | os.O_CREAT, 0o666)
+        except PermissionError as e:
+            print(
+                f"\n[ERROR] Cannot open lock file {LOCK_FILE}: {e}\n"
+                f"        A stale lock file with restrictive permissions exists.\n"
+                f"        Remove it and retry:  sudo rm {LOCK_FILE}\n",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    finally:
+        os.umask(old_umask)
+
+    # Repair perms on a file left behind by an older version of this
+    # script (no-op unless we are the owner or root).
+    try:
+        os.chmod(LOCK_FILE, 0o666)
     except OSError:
-        print("\n[ERROR] bxi_example_hw is already running! "
-              "Please stop the existing instance before starting a new one.\n",
-              file=sys.stderr)
-        _lock_fd.close()
-        _lock_fd = None
+        pass
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            holder = os.read(fd, 64).decode("utf-8", errors="replace").strip() or "unknown"
+        except OSError:
+            holder = "unknown"
+        os.close(fd)
+        print(
+            f"\n[ERROR] bxi_example_hw is already running (pid={holder})! "
+            f"Please stop the existing instance before starting a new one.\n",
+            file=sys.stderr,
+        )
         sys.exit(1)
-    _lock_fd.write(str(os.getpid()))
-    _lock_fd.flush()
+
+    os.ftruncate(fd, 0)
+    os.write(fd, str(os.getpid()).encode("utf-8"))
+    _lock_fd = fd
+    atexit.register(_release_lock)
 
 def generate_launch_description():
     _acquire_lock()


### PR DESCRIPTION
## 背景

`src/bxi_example_py_elf3/launch/example_demo_hw.launch.py` 里的 `_acquire_lock()` 实现存在两个问题：

1. **跨用户权限失败**：用 `open(LOCK_FILE, "w")` 创建 `/tmp/bxi_example_hw.lock`，文件权限受当前 umask 影响通常落在 `0o644`，归创建者所有。换一个非 root 用户再启动时 `open("w")` 抛 `PermissionError`，被外层 `except OSError` 一把吞掉，输出的是误导性的"already running"。即使切到 root 起一次，旧文件的 `0o644` 权限也没有被自动修复，下一次普通用户跑还是同样的问题。
2. **truncate 早于上锁**：`"w"` 模式打开文件时立刻清零内容。如果此时确实有另一个实例在运行并往文件里写了 PID，就被先 truncate 掉了，错误提示里也就没法显示真正占着锁的进程号。

## 修改内容

- 改用 `os.open(LOCK_FILE, O_RDWR | O_CREAT, 0o666)`，并在调用前后用 `try/finally` 临时把 `umask` 置 0，确保新建的锁文件就是世界可写的 `0o666`。
- 打开后调用 `os.chmod(LOCK_FILE, 0o666)`，best-effort 修复旧版本残留的 `0o644` 文件（不是文件 owner 或 root 时是 no-op，root 跑一次就能一次性恢复）。
- 单独捕获 `PermissionError`，输出明确的 `sudo rm /tmp/bxi_example_hw.lock` 恢复指引，不再把权限问题伪装成"already running"。
- 上锁成功之后才 `ftruncate(0)` + 写 PID，避免破坏正在运行实例的 PID 记录。
- 锁被占用时 `lseek` 到文件头读取持有者 PID 一起打印到报错里。
- 新增 `_release_lock()` 并通过 `atexit.register` 注册，正常退出时执行 `flock(LOCK_UN)` + `close(fd)` 干净释放。
- 故意不 `unlink` 锁文件，避免两个进程在 unlink 的时间窗里各自打开到不同 inode 上、各自拿到 flock 的 TOCTOU 竞态。SIGKILL 等异常退出也不影响：内核会自动释放 flock，文件保留时已经是 `0o666`，下一次任何用户都能直接复用。
- `_acquire_lock()` 入口加一个已持有判断，避免同一进程内重入。

## 测试计划

- [ ] 普通用户跑 `ros2 launch bxi_example_py_elf3 example_demo_hw.launch.py`，Ctrl+C 退出
- [ ] `ls -l /tmp/bxi_example_hw.lock` 看到 `-rw-rw-rw-`
- [ ] 切到另一个非 root 用户再起一次，能正常 acquire，不会报权限/误报"already running"
- [ ] 一个实例已经在跑的情况下再起一个，错误提示里能看到持有者 PID
- [ ] 在旧代码残留的 `0o644` 文件上用 root 跑一次，之后普通用户起不再需要手动 `sudo rm`