### PR TITLE
remote_events 透传 slot/value 到状态机话题

### DIFF
--- a/src/bxi_example_py_elf3/bxi_example_py_elf3/utils/state_machine.py
+++ b/src/bxi_example_py_elf3/bxi_example_py_elf3/utils/state_machine.py
@@ -481,7 +481,7 @@ class RobotStateMachine(Generic[CtxT]):
                 name: self._profile_snapshot(profile)
                 for name, profile in self._profiles.items()
             },
-            "remote_events": list((self._config.get("remote_events", {}) or {}).keys()),
+            "remote_events": dict(self._config.get("remote_events", {}) or {}),
             "transitions": [
                 {
                     "from": from_state,


### PR DESCRIPTION
## Summary

- `_graph_snapshot()` 把 `remote_events` 输出从事件名 list 改成完整 dict，透传 yaml 里每个事件的 `slot`/`value` 以及可选 `ui` 子字段
- 让下游订阅 `state_machine_info` 的服务（如机器人远控网关 `bxi_rc_ros2`）能直接从话题 JSON 拿到完整的 (event_name, slot, value) 映射，无需另外去解析 yaml

## Motivation

下游 app 想做动态按钮 UI 时，需要知道 "按钮 → 事件" 的完整映射：

```yaml
back_flip_event:
  slot: btn_10
  value: 1
```

之前网关只能去单独读 yaml 文件（路径硬编码、版本可能不同步），现在订阅话题就够了。

## Test plan

- [ ] `ros2 topic echo /hardware/state_machine_info | jq '.graph.remote_events'` 应能看到完整 dict 而非字符串 list
- [ ] 已有依赖此字段的下游脚本不受影响（dict 仍可迭代得到 keys）

## Compatibility

向后兼容——之前消费 `remote_events` 的代码当它是 Iterable，dict 同样可迭代得到 keys；只有依赖 `isinstance(x, list)` 的才会受影响。
