### PR TITLE
ARM64 Build and Release

### DIFF
--- a/.github/workflows/arm64-build.yml
+++ b/.github/workflows/arm64-build.yml
@@ -1,9 +1,17 @@
-name: Auto Build and Release
+name: ARM64 Build and Release
 
 on:
   push:
     branches: ["main"]
+  pull_request:
+    branches: ["main"]
   workflow_dispatch:
+    inputs:
+      upload:
+        description: Upload the ARM64 package to the download site
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -12,10 +20,11 @@ env:
   ROBOT_MODEL: ELF3
   PACKAGE_NAME: bxi_rl_controller_ros2_example
   PACKAGE_TARGET_PATH: /opt/bxi/bxi_rl_controller_ros2_example
+  BXI_ROS2_REF: arm64
 
 jobs:
   build-and-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04-arm
     container:
       image: ghcr.io/sloretz/ros:humble-desktop-full
     defaults:
@@ -47,15 +56,16 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-ccache-${{ github.ref }}
+          key: ${{ runner.os }}-arm64-ccache-${{ github.ref }}
           update-package-index: true
           restore-keys: |
-            ${{ runner.os }}-ccache-
+            ${{ runner.os }}-arm64-ccache-
 
       - name: Fetch bxi_ros2_pkg
         run: |
           mkdir -p /opt/bxi
-          git clone --depth 1 https://github.com/bxirobotics/bxi_ros2_pkg.git /opt/bxi/bxi_ros2_pkg
+          git clone --depth 1 --branch "$BXI_ROS2_REF" \
+            https://github.com/bxirobotics/bxi_ros2_pkg.git /opt/bxi/bxi_ros2_pkg
 
       - name: Build Controller Package
         run: |
@@ -86,13 +96,14 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: bxi_rl_controller_ros2_example_package
+          name: bxi_rl_controller_ros2_example_arm64_package
           path: |
             bxi_rl_controller_ros2_example_${{ env.tag_name }}.tar.gz
             bxi_rl_controller_ros2_example_${{ env.tag_name }}.tar.gz.sha256
           retention-days: 7
 
       - name: SCP Upload Package Files
+        if: github.event_name == 'push' || inputs.upload
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.SSH_HOST }}
@@ -100,14 +111,4 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT || 22 }}
           source: bxi_rl_controller_ros2_example_${{ env.tag_name }}.tar.gz,bxi_rl_controller_ros2_example_${{ env.tag_name }}.tar.gz.sha256
-          target: ${{ secrets.DEPLOY_PATH }}/${{ env.PACKAGE_NAME }}
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.tag_name }}
-          name: "Release ${{ env.tag_name }}"
-          files: |
-            bxi_rl_controller_ros2_example_${{ env.tag_name }}.tar.gz
-            bxi_rl_controller_ros2_example_${{ env.tag_name }}.tar.gz.sha256
-          generate_release_notes: true
+          target: ${{ secrets.DEPLOY_PATH }}/arm64/${{ env.PACKAGE_NAME }}


### PR DESCRIPTION
新增与 main 发布流程对应的 ARM64 构建与部署工作流。工作流使用 bxi_ros2_pkg 的 arm64 分支；main 推送时将包上传至 /ELF3/arm64/bxi_rl_controller_ros2_example。PR 默认仅构建、打包并上传 Actions 产物；手动运行时可显式开启上传以验证 SCP。